### PR TITLE
SNOW-2879161: Keep semgrep required workflow as placeholder

### DIFF
--- a/required_workflows/semgrep.yml
+++ b/required_workflows/semgrep.yml
@@ -11,13 +11,7 @@ jobs:
   semgrep:
     name: Scan
     runs-on: ubuntu-latest
-    env:
-      SEMGREP_APP_URL: https://snowflake.semgrep.dev
-      PUBLISH_DEPLOYMENT: 1
-      SEMGREP_APP_TOKEN: ${{ secrets.token }}
-    container:
-      image: returntocorp/semgrep:latest
     if: (github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, 'PR Canary'))
     steps:
-      - uses: actions/checkout@v3
-      - run: semgrep ci
+      - name: Semgrep Placeholder
+        run: echo "Semgrep Placeholder"


### PR DESCRIPTION
## Summary
- Keep `required_workflows/semgrep.yml` as a placeholder-only workflow.
- Remove active semgrep execution/runtime config and keep the no-op placeholder step.
- Preserve the existing PR guard condition.