### PR TITLE
SNOW-2879161: Keep semgrep-v2 workflow as placeholder

### DIFF
--- a/.github/workflows/semgrep-v2.yml
+++ b/.github/workflows/semgrep-v2.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: (github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, 'PR Canary'))
     steps:
       - name: Semgrep Placeholder

--- a/.github/workflows/semgrep-v2.yml
+++ b/.github/workflows/semgrep-v2.yml
@@ -12,14 +12,8 @@ permissions:
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-22.04
-    env:
-      SEMGREP_APP_URL: https://snowflake.semgrep.dev
-      PUBLISH_DEPLOYMENT: 1
-      SEMGREP_APP_TOKEN: ${{ secrets.token }}
-    container:
-      image: returntocorp/semgrep:latest
+    runs-on: ubuntu-latest
     if: (github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, 'PR Canary'))
     steps:
-      - uses: actions/checkout@v3
-      - run: semgrep ci
+      - name: Semgrep Placeholder
+        run: echo "Semgrep Placeholder"


### PR DESCRIPTION
## Summary
- Disable `.github/workflows/semgrep-v2.yml` by keeping a placeholder-only semgrep job.
- Remove active semgrep runtime/execution configuration and retain the PR guard condition.
